### PR TITLE
upgraded androidx.appcompat to 1.2.0

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -18,7 +18,7 @@ object Versions {
     const val KOTLIN = "1.4.0"
     const val KOTLIN_COROUTINES = "1.3.9"
 
-    const val ANDROIDX_APPCOMPAT = "1.1.0"
+    const val ANDROIDX_APPCOMPAT = "1.2.0"
     const val ANDROIDX_FRAGMENT = "1.2.4"
 
     const val ANDROIDX_CORE = "1.3.1"


### PR DESCRIPTION
   - Release Date: 8 6 2020
   - Size: 1.06 MB
   - Releases notes: https://developer.android.com/jetpack/androidx/releases/appcompat
   - Source code: https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/appcompat/
   - Issue tracker: https://issuetracker.google.com/issues?q=componentid:460343