### PR TITLE
upgrade android gradle tools to 4.1.0

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -67,7 +67,7 @@ object Versions {
     const val KTLINT = "0.37.1"
 
     // build libs
-    const val ANDROID_GRADLE_TOOL = "4.0.2"
+    const val ANDROID_GRADLE_TOOL = "4.1.0"
     const val SCABBARD = "0.4.0"
     const val RELEASES_HUB = "1.6.0"
 }


### PR DESCRIPTION
   - Release Date: 10 13 2020
   - Size: 5.76 MB
   - Releases notes: https://developer.android.com/studio/releases/gradle-plugin
   - Documentation: https://developer.android.com/studio/build/
   - Issue tracker: https://issuetracker.google.com/issues?q=componentid:192709