### PR TITLE
upgrade dagger to 2.29.1

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -33,7 +33,7 @@ object Versions {
     const val ANDROIDX_VIEWPAGER2 = "1.0.0-beta03"
     const val ANDROIDX_SWIPE_REFRESH_LAYOUT = "1.0.0"
 
-    const val DAGGER = "2.27"
+    const val DAGGER = "2.29.1"
 
     const val RXJAVA = "2.2.19"
     const val RXJAVA_ANDROID = "2.1.1"


### PR DESCRIPTION
   - Release Date: 9 11 2020
   - Size: 17.47 KB
   - Releases notes: https://github.com/google/dagger/releases
   - Source code: https://github.com/google/dagger
   - Documentation: https://google.github.io/dagger/
   - Issue tracker: https://github.com/google/dagger/issues